### PR TITLE
prometheus-systemd-exporter: Fix NixOS test to follow 0.4.0 -> 0.5.0

### DIFF
--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1181,21 +1181,21 @@ let
         enable = true;
 
         extraFlags = [
-          "--collector.enable-restart-count"
+          "--systemd.collector.enable-restart-count"
         ];
       };
       metricProvider = { };
       exporterTest = ''
         wait_for_unit("prometheus-systemd-exporter.service")
         wait_for_open_port(9558)
-        succeed(
+        wait_until_succeeds(
             "curl -sSf localhost:9558/metrics | grep '{}'".format(
                 'systemd_unit_state{name="basic.target",state="active",type="target"} 1'
             )
         )
         succeed(
             "curl -sSf localhost:9558/metrics | grep '{}'".format(
-                'systemd_service_restart_total{state="prometheus-systemd-exporter.service"} 0'
+                'systemd_service_restart_total{name="prometheus-systemd-exporter.service"} 0'
             )
         )
       '';


### PR DESCRIPTION
###### Motivation for this change
prometheus-systemd-exporter [0.4.0 → 0.5.0](https://github.com/prometheus-community/systemd_exporter/compare/v0.4.0...v0.5.0) changes the name of some flags and fields.  The NixOS test must be updated to follow those changes.  :(

cc @r-ryantm, to be integrated into https://github.com/NixOS/nixpkgs/pull/184452