### PR TITLE
python311Packages.cantools: add optional-dependencies, rm postPatch

### DIFF
--- a/pkgs/development/python-modules/cantools/default.nix
+++ b/pkgs/development/python-modules/cantools/default.nix
@@ -27,11 +27,6 @@ buildPythonPackage rec {
     hash = "sha256-WU8q6A3q24xrCOjhMi1C4lj0DULIDWiG2E4BQ/kLWiM=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "setuptools_scm>=8" "setuptools_scm"
-  '';
-
   nativeBuildInputs = [
     setuptools
     setuptools-scm
@@ -43,14 +38,17 @@ buildPythonPackage rec {
     can
     crccheck
     diskcache
-    matplotlib
     textparser
+  ];
+
+  passthru.optional-dependencies.plot = [
+    matplotlib
   ];
 
   nativeCheckInputs = [
     parameterized
     pytestCheckHook
-  ];
+  ] ++ passthru.optional-dependencies.matplotlib;
 
   pythonImportsCheck = [
     "cantools"


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @ [dotlambda](https://github.com/dotlambda) 
