### PR TITLE
 tail-tray: 0.2.13 -> 0.2.14

### DIFF
--- a/pkgs/by-name/te/tetris/package.nix
+++ b/pkgs/by-name/te/tetris/package.nix
@@ -1,0 +1,63 @@
+{
+  haskellPackages,
+  haskell,
+}:
+
+haskell.lib.compose.justStaticExecutables (
+  haskellPackages.callPackage (
+    {
+      mkDerivation,
+      fetchFromGitHub,
+      lib,
+
+      base,
+      vty,
+      lens,
+      brick,
+      linear,
+      containers,
+      random,
+      transformers,
+      directory,
+      filepath,
+      optparse-applicative,
+      vty-crossplatform,
+      mtl,
+      extra,
+    }:
+    mkDerivation rec {
+      pname = "tetris";
+      version = "0.1.6";
+      src = fetchFromGitHub {
+        repo = "tetris";
+        owner = "Samtay";
+        tag = "v${version}";
+        hash = "sha256-xA2/n5zY01BLKlUI8BVvfuUvsqh2U23XOooTQwXkDpQ=";
+      };
+      libraryHaskellDepends = [
+        base
+        brick
+        containers
+        extra
+        lens
+        linear
+        mtl
+        random
+        transformers
+        vty
+        vty-crossplatform
+      ];
+      executableHaskellDepends = [
+        base
+        directory
+        filepath
+        optparse-applicative
+      ];
+      homepage = "https://github.com/samtay/tetris";
+      changelog = "https://github.com/samtay/tetris/releases/tag/v${version}";
+      license = lib.licenses.bsd3;
+      mainProgram = "tetris";
+      maintainers = [ lib.maintainers.Svenum ];
+    }
+  ) { }
+)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @
