### PR TITLE
libsideswap-client: 0-unstable-2025-06-05 -> 0-unstable-2025-06-24

### DIFF
--- a/pkgs/by-name/si/sideswap/libsideswap-client.nix
+++ b/pkgs/by-name/si/sideswap/libsideswap-client.nix
@@ -9,17 +9,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "libsideswap-client";
-  version = "0-unstable-2025-06-05";
+  version = "0-unstable-2025-06-24";
 
-  # This version is pinned in https://github.com/sideswap-io/sideswapclient/blob/v1.8.0/deploy/build_linux.sh
+  # This version is pinned in https://github.com/sideswap-io/sideswapclient/blob/v1.8.1/deploy/build_linux.sh
   src = fetchFromGitHub {
     owner = "sideswap-io";
     repo = "sideswap_rust";
-    rev = "0ba7485f77c86d1a6ae64a0cfedba22afe4ed98a";
-    hash = "sha256-6qfFpCE6DMZlKuhQbXjJmmb8rPxFB2TA7CpOk06tuDk=";
+    rev = "91791efbceb3fac4774d1e42a519e70b14b876cf";
+    hash = "sha256-SUAmmKnL/thGLfPU22UxzO+LVXgrHh+lZVdXuAJ4q1E=";
   };
 
-  cargoHash = "sha256-ecftCyNMRWdFP5SDEmLnssTVSfg9mo/TQEqyeDj4VpQ=";
+  cargoHash = "sha256-bbNFi0cmFFf66IDKi0V8HC/lSU3JLRpgZ+NHeMJog8c=";
 
   # sideswap_client uses vergen to detect Git commit hash at build time. It
   # tries to access .git directory which is not present in Nix build dir.


### PR DESCRIPTION
This is needed to sync it with the version used by upstream: https://github.com/sideswap-io/sideswapclient/blob/v1.8.1/deploy/build_linux.sh

I propose to squash this into https://github.com/NixOS/nixpkgs/pull/421242

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @r-ryantm 
